### PR TITLE
Default behaviour - to include Cellar kegs and option to disable it

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It can also automatically include the formula's dependencies:
 
 ## Installing it
 
-brew-pkg is available from my [formulae tap](https://github.com/timsutton/homebrew-formulae). Add the tap:
+brew-pkg is available from my [formulae tap](https://github.com/kaloprominat/homebrew-formulae). Add the tap:
 
 `brew tap kaloprominat/formulae`
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ brew-pkg is a Homebrew external command that builds an OS X installer package fr
 
 Assuming nginx is already installed:
 
-`brew pkg nginx`
+`brew pkg --id-prefix org.homebrew nginx`
 <code><pre>==> Creating package staging root using Homebrew prefix /usr/local
 ==> Staging formula nginx
 ==> Plist found at homebrew.mxcl.nginx, staging for /Library/LaunchDaemons/homebrew.mxcl.nginx.plist
@@ -14,7 +14,7 @@ Assuming nginx is already installed:
 
 It can also automatically include the formula's dependencies:
 
-`brew pkg --with-deps ffmpeg`
+`brew pkg --with-deps --without-kegs ffmpeg`
 <code><pre>==> Creating package staging root using Homebrew prefix /usr/local
 ==> Staging formula ffmpeg
 ==> Staging formula pkg-config
@@ -30,7 +30,7 @@ It can also automatically include the formula's dependencies:
 
 brew-pkg is available from my [formulae tap](https://github.com/timsutton/homebrew-formulae). Add the tap:
 
-`brew tap timsutton/formulae`
+`brew tap kaloprominat/formulae`
 
 Then install as any other formula:
 
@@ -40,7 +40,7 @@ Then install as any other formula:
 
 If a formula has defined a launchd plist, brew-pkg will also install this to the package's root in `/Library/LaunchDaemons`.
 
-You can also define a custom identifier prefix in the reverse-domain convention with the `--identifier-prefix` option, ie. `brew pkg --identifier-prefix org.nagios nrpe`. If there is a launchd plist defined, this same prefix is currently _not_ applied to the plist.
+You can also define a custom identifier prefix in the reverse-domain convention with the `--id-prefix` option, ie. `brew pkg --id-prefix org.nagios nrpe`. If there is a launchd plist defined, this same prefix is currently _not_ applied to the plist.
 
 You can set the path to custom preinstall and postinstall scripts with the `--scripts` option which is just literally passed through to the `pkgbuild` command.  
 For more information refer to `man pkgbuild` which explains that *`--scripts scripts_path` archive the entire contents of scripts-path as the package scripts. If this directory contains scripts named preinstall and/or postinstall, these will be run as the top-level scripts of the package [...]*.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ brew-pkg is a Homebrew external command that builds an OS X installer package fr
 
 Assuming nginx is already installed:
 
-`brew pkg --id-prefix org.homebrew nginx`
+`brew pkg org.homebrew nginx`
 <code><pre>==> Creating package staging root using Homebrew prefix /usr/local
 ==> Staging formula nginx
 ==> Plist found at homebrew.mxcl.nginx, staging for /Library/LaunchDaemons/homebrew.mxcl.nginx.plist
@@ -40,7 +40,7 @@ Then install as any other formula:
 
 If a formula has defined a launchd plist, brew-pkg will also install this to the package's root in `/Library/LaunchDaemons`.
 
-You should also define a custom identifier prefix in the reverse-domain convention with the `--id-prefix` option, ie. `brew pkg --id-prefix org.nagios nrpe`. If there is a launchd plist defined, this same prefix is currently _not_ applied to the plist.
+You can also define a custom identifier prefix in the reverse-domain convention with the `--identifier-prefix` option, ie. `brew pkg --identifier-prefix org.nagios nrpe`. If there is a launchd plist defined, this same prefix is currently _not_ applied to the plist.
 
 You can set the path to custom preinstall and postinstall scripts with the `--scripts` option which is just literally passed through to the `pkgbuild` command.  
 For more information refer to `man pkgbuild` which explains that *`--scripts scripts_path` archive the entire contents of scripts-path as the package scripts. If this directory contains scripts named preinstall and/or postinstall, these will be run as the top-level scripts of the package [...]*.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ It can also automatically include the formula's dependencies:
 
 ## Installing it
 
-brew-pkg is available from my [formulae tap](https://github.com/kaloprominat/homebrew-formulae). Add the tap:
+brew-pkg is available from my [formulae tap](https://github.com/timsutton/homebrew-formulae). Add the tap:
 
-`brew tap kaloprominat/formulae`
+`brew tap timsutton/formulae`
 
 Then install as any other formula:
 
@@ -40,7 +40,7 @@ Then install as any other formula:
 
 If a formula has defined a launchd plist, brew-pkg will also install this to the package's root in `/Library/LaunchDaemons`.
 
-You can also define a custom identifier prefix in the reverse-domain convention with the `--id-prefix` option, ie. `brew pkg --id-prefix org.nagios nrpe`. If there is a launchd plist defined, this same prefix is currently _not_ applied to the plist.
+You should also define a custom identifier prefix in the reverse-domain convention with the `--id-prefix` option, ie. `brew pkg --id-prefix org.nagios nrpe`. If there is a launchd plist defined, this same prefix is currently _not_ applied to the plist.
 
 You can set the path to custom preinstall and postinstall scripts with the `--scripts` option which is just literally passed through to the `pkgbuild` command.  
 For more information refer to `man pkgbuild` which explains that *`--scripts scripts_path` archive the entire contents of scripts-path as the package scripts. If this directory contains scripts named preinstall and/or postinstall, these will be run as the top-level scripts of the package [...]*.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ brew-pkg is a Homebrew external command that builds an OS X installer package fr
 
 Assuming nginx is already installed:
 
-`brew pkg org.homebrew nginx`
+`brew pkg nginx`
 <code><pre>==> Creating package staging root using Homebrew prefix /usr/local
 ==> Staging formula nginx
 ==> Plist found at homebrew.mxcl.nginx, staging for /Library/LaunchDaemons/homebrew.mxcl.nginx.plist
@@ -25,6 +25,8 @@ It can also automatically include the formula's dependencies:
 ==> Staging formula lame
 ==> Staging formula xvid
 ==> Building package ffmpeg-1.1.pkg</pre></code>
+
+By default behaviour brew pkg include all package kegs located in /usr/local/Cellar/packagename. If you need to exclude it, specify option --without-kegs
 
 ## Installing it
 

--- a/brew-pkg.rb
+++ b/brew-pkg.rb
@@ -13,11 +13,11 @@ end
 module Homebrew extend self
   def pkg
     unpack_usage = <<-EOS
-Usage: brew pkg [--identifier-prefix prefix] [--with-deps] [--without-kegs] formula
+Usage: brew pkg [--identifier-prefix] [--with-deps] [--without-kegs] formula
 
 Build an OS X installer package from a formula. It must be already
 installed; 'brew pkg' doesn't handle this for you automatically. The
-'--identifier-prefix' option is required in order to follow
+'--identifier-prefix' option is strongly recommended in order to follow
 the conventions of OS X installer packages.
 
 Options:

--- a/brew-pkg.rb
+++ b/brew-pkg.rb
@@ -66,13 +66,25 @@ Options:
       dep_version = formula.version.to_s
       dep_version += "_#{formula.revision}" if formula.revision.to_s != '0'
 
+
       ohai "Staging formula #{formula.name}"
       # Get all directories for this keg, rsync to the staging root
-      dirs = Pathname.new(File.join(HOMEBREW_CELLAR, formula.name, dep_version)).children.select { |c| c.directory? }.collect { |p| p.to_s }
-      dirs.each {|d| safe_system "rsync", "-a", "#{d}", "#{staging_root}/" }
 
-      safe_system "mkdir", "-p", "#{staging_root}/Cellar/#{formula.name}/"
-      safe_system "rsync", "-a", "#{HOMEBREW_CELLAR}/#{formula.name}/#{formula.version}", "#{staging_root}/Cellar/#{formula.name}/"
+      if File.exists?(File.join(HOMEBREW_CELLAR, formula.name, dep_version))
+
+        dirs = Pathname.new(File.join(HOMEBREW_CELLAR, formula.name, dep_version)).children.select { |c| c.directory? }.collect { |p| p.to_s }
+
+
+        dirs.each {|d| safe_system "rsync", "-a", "#{d}", "#{staging_root}/" }
+
+        ohai "Staging directory #{HOMEBREW_CELLAR}/#{formula.name}/#{dep_version}"
+
+        if File.exists?("#{HOMEBREW_CELLAR}/#{formula.name}/#{dep_version}")
+          safe_system "mkdir", "-p", "#{staging_root}/Cellar/#{formula.name}/"
+          safe_system "rsync", "-a", "#{HOMEBREW_CELLAR}/#{formula.name}/#{dep_version}", "#{staging_root}/Cellar/#{formula.name}/"
+        end
+
+      end
 
       # Write out a LaunchDaemon plist if we have one
       if formula.plist

--- a/brew-pkg.rb
+++ b/brew-pkg.rb
@@ -13,7 +13,7 @@ end
 module Homebrew extend self
   def pkg
     unpack_usage = <<-EOS
-Usage: brew pkg --id-prefix prefix [--with-deps] [--without-kegs] formula
+Usage: brew pkg [--identifier-prefix prefix] [--with-deps] [--without-kegs] formula
 
 Build an OS X installer package from a formula. It must be already
 installed; 'brew pkg' doesn't handle this for you automatically. The

--- a/brew-pkg.rb
+++ b/brew-pkg.rb
@@ -17,11 +17,11 @@ Usage: brew pkg [--identifier-prefix prefix] [--with-deps] [--without-kegs] form
 
 Build an OS X installer package from a formula. It must be already
 installed; 'brew pkg' doesn't handle this for you automatically. The
-'--id-prefix' option is required in order to follow
+'--identifier-prefix' option is required in order to follow
 the conventions of OS X installer packages.
 
 Options:
-  --id-prefix             set a custom identifier prefix to be prepended
+  --identifier-prefix     set a custom identifier prefix to be prepended
                           to the built package's identifier, ie. 'org.nagios'
                           makes a package identifier called 'org.nagios.nrpe'
   --with-deps             include all the package's dependencies in the built package
@@ -30,10 +30,10 @@ Options:
     EOS
 
     abort unpack_usage if ARGV.empty?
-    identifier_prefix = if ARGV.include? '--id-prefix'
+    identifier_prefix = if ARGV.include? '--identifier-prefix'
       ARGV.next.chomp(".")
     else
-      abort unpack_usage
+      'org.homebrew'
     end
 
     f = Formula.factory ARGV.last

--- a/brew-pkg.rb
+++ b/brew-pkg.rb
@@ -69,6 +69,7 @@ Options:
       ohai "Staging formula #{formula.name}"
       # Get all directories for this keg, rsync to the staging root
       dirs = Pathname.new(File.join(HOMEBREW_CELLAR, formula.name, dep_version)).children.select { |c| c.directory? }.collect { |p| p.to_s }
+      dirs.push("#{HOMEBREW_CELLAR}/#{formula.name}/#{formula.version}")
       dirs.each {|d| safe_system "rsync", "-a", "#{d}", "#{staging_root}/" }
 
       # Write out a LaunchDaemon plist if we have one

--- a/brew-pkg.rb
+++ b/brew-pkg.rb
@@ -69,8 +69,10 @@ Options:
       ohai "Staging formula #{formula.name}"
       # Get all directories for this keg, rsync to the staging root
       dirs = Pathname.new(File.join(HOMEBREW_CELLAR, formula.name, dep_version)).children.select { |c| c.directory? }.collect { |p| p.to_s }
-      dirs.push("#{HOMEBREW_CELLAR}/#{formula.name}/#{formula.version}")
       dirs.each {|d| safe_system "rsync", "-a", "#{d}", "#{staging_root}/" }
+
+      safe_system "mkdir", "-p", "#{staging_root}/Cellar/#{formula.name}/"
+      safe_system "rsync", "-a", "#{HOMEBREW_CELLAR}/#{formula.name}/#{formula.version}", "#{staging_root}/Cellar/#{formula.name}/"
 
       # Write out a LaunchDaemon plist if we have one
       if formula.plist


### PR DESCRIPTION
Hi, timsutton.

As some users mentioned at issues page, brew pkg skips kegs in Cellar directory, but many packages compiled with static linking to those directories. I've modified brew pkg default behaviour to include package kegs too and added option --without-kegs to disable it.

Looking forward for your review. Thanks.