### PR TITLE
Fix ARGV.next method not found

### DIFF
--- a/brew-pkg.rb
+++ b/brew-pkg.rb
@@ -100,10 +100,10 @@ Options:
       end
     end
 
-    # Add scripts if we specified --scripts 
+    # Add scripts if we specified --scripts
     found_scripts = false
     if ARGV.include? '--scripts'
-      scripts_path = ARGV.next
+      scripts_path = ARGV[ARGV.index('--scripts') + 1]
       if File.directory?(scripts_path)
         pre = File.join(scripts_path,"preinstall")
         post = File.join(scripts_path,"postinstall")
@@ -126,7 +126,7 @@ Options:
     # Custom ownership
     found_ownership = false
     if ARGV.include? '--ownership'
-      custom_ownership = ARGV.next
+      custom_ownership = ARGV[ARGV.index('--ownership') + 1]
        if ['recommended', 'preserve', 'preserve-other'].include? custom_ownership
         found_ownership = true
         ohai "Setting pkgbuild option --ownership with value #{custom_ownership}"
@@ -146,11 +146,11 @@ Options:
     ]
     if found_scripts
       args << "--scripts"
-      args << scripts_path 
+      args << scripts_path
     end
     if found_ownership
       args << "--ownership"
-      args << custom_ownership 
+      args << custom_ownership
     end
     args << "#{pkgfile}"
     safe_system "pkgbuild", *args


### PR DESCRIPTION
Fixes the following issue:
```
$ brew pkg --with-deps --scripts scripts filebeat
[...]
Error: undefined method `next' for ["--with-deps", "--scripts", "scripts", "filebeat"]:Array
/usr/local/bin/brew-pkg.rb:106:in `pkg'
/usr/local/bin/brew-pkg.rb:162:in `<top (required)>'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/usr/local/Homebrew/Library/Homebrew/utils.rb:86:in `require?'
/usr/local/Homebrew/Library/Homebrew/brew.rb:121:in `<main>'
```

I'm not a Ruby dev, so maybe there is a better way to do it.