### PR TITLE
Modern homebrew links cellar in /usr/local/opt too

### DIFF
--- a/brew-pkg.rb
+++ b/brew-pkg.rb
@@ -85,6 +85,8 @@ Options:
 
           safe_system "mkdir", "-p", "#{staging_root}/Cellar/#{formula.name}/"
           safe_system "rsync", "-a", "#{HOMEBREW_CELLAR}/#{formula.name}/#{dep_version}", "#{staging_root}/Cellar/#{formula.name}/"
+          safe_system "mkdir", "-p", "#{staging_root}/opt"
+          safe_system "ln", "-s", "../Cellar/#{formula.name}/#{dep_version}", "#{staging_root}/opt/#{formula.name}"
         end
 
       end

--- a/brew-pkg.rb
+++ b/brew-pkg.rb
@@ -11,6 +11,7 @@ end
 
 # cribbed Homebrew module code from brew-unpack.rb
 module Homebrew extend self
+  include Utils::Output::Mixin
   def pkg
     unpack_usage = <<-EOS
 Usage: brew pkg [--identifier-prefix] [--with-deps] [--without-kegs] formula

--- a/brew-pkg.rb
+++ b/brew-pkg.rb
@@ -92,6 +92,16 @@ Options:
 
       end
 
+      # Stage etc/ files for this formula (e.g. openssl@3 CA certs, config files)
+      # These live outside the Cellar at HOMEBREW_PREFIX/etc/<formula_name>/
+      # and are typically created during `brew postinstall`.
+      etc_dir = File.join(HOMEBREW_PREFIX, "etc", formula.name)
+      if File.exist?(etc_dir)
+        ohai "Staging etc directory #{etc_dir}"
+        safe_system "mkdir", "-p", "#{staging_root}/etc/"
+        safe_system "rsync", "-a", "#{etc_dir}", "#{staging_root}/etc/"
+      end
+
       # Write out a LaunchDaemon plist if we have one
       if formula.service?
         ohai "Plist found at #{formula.plist_name}, staging for /Library/LaunchDaemons/#{formula.plist_name}.plist"

--- a/brew-pkg.rb
+++ b/brew-pkg.rb
@@ -57,7 +57,7 @@ Options:
     FileUtils.mkdir_p staging_root
 
 
-    pkgs = [f]
+    pkgs = [ARGV.last]
 
     # Add deps if we specified --with-deps
     pkgs += f.recursive_dependencies if ARGV.include? '--with-deps'


### PR DESCRIPTION
Was getting errors on git installs using brew pkg. Complaining it couldn't find templates. Added a creation of `/usr/local/opt/<pkg>` to the latest cellar version too in the script fixes the issue.